### PR TITLE
Skip nokogiri

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -20,16 +20,13 @@ module Jekyll
 
     def generate(site)
       @site = site
+      @filter = HTML::Pipeline::EmojiFilter.new(nil, { :asset_root => src })
       site.pages.each { |page| emojify page }
       site.posts.each { |page| emojify page }
     end
 
     def emojify(page)
-      filter = HTML::Pipeline::EmojiFilter.new(
-        "<#{TAG}>#{page.content}</#{TAG}>",
-        { :asset_root => src }
-      )
-      page.content = filter.call.search(TAG).children.to_xml
+      page.content = @filter.emoji_image_filter(page.content)
     end
   end
 end

--- a/test/test_jemoji.rb
+++ b/test/test_jemoji.rb
@@ -9,10 +9,11 @@ class TestJemoji < Test::Unit::TestCase
     @page = Jekyll::Page.new(@site, File.expand_path("../../", __FILE__), "", "README.md")
     @page.instance_variable_set "@content", ":+1:"
     @site.pages.push @page
-    @img = "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"http://assets.github.com/images/icons/emoji/%2B1.png\" height=\"20\" width=\"20\" align=\"absmiddle\"/>"
+    @img = "<img class='emoji' title=':+1:' alt=':+1:' src='http://assets.github.com/images/icons/emoji/%2B1.png' height='20' width='20' align='absmiddle' />"
   end
 
   should "replace emoji with img" do
+    @jemoji.instance_variable_set "@filter", HTML::Pipeline::EmojiFilter.new(nil, { :asset_root => @jemoji.src })
     @jemoji.emojify @page
     assert_equal @img, @page.content
   end
@@ -28,11 +29,12 @@ class TestJemoji < Test::Unit::TestCase
   end
 
   should "not mangle liquid templates" do
+    @jemoji.instance_variable_set "@filter", HTML::Pipeline::EmojiFilter.new(nil, { :asset_root => @jemoji.src })
     page = Jekyll::Page.new(@site, File.expand_path("../../", __FILE__), "", "README.md")
-    page.instance_variable_set "@content", ":+1: <a href=\"{{ page.permalink }}\">foo</a>"
+    page.instance_variable_set "@content", ":+1: <a href='{{ page.permalink }}'>foo</a>"
 
     @jemoji.emojify page
-    assert_equal "#{@img}<a href=\"{{ page.permalink }}\">foo</a>", page.content
+    assert_equal "#{@img} <a href='{{ page.permalink }}'>foo</a>", page.content
   end
 
 end


### PR DESCRIPTION
Call `emoji_image_filter` directly.
