### PR TITLE
Fix double emojification and deal with deprecations for Jekyll v3

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -25,13 +25,17 @@ module Jekyll
     end
 
     def generate(site)
-      site.pages.each { |page| emojify page }
-      site.posts.each { |post| emojify post }
+      site.posts.each { |doc| emojify doc } unless v3?
+      site.pages.each { |doc| emojify doc }
       site.docs_to_write.each { |doc| emojify doc }
     end
 
     def emojify(page)
       page.content = filter.emoji_image_filter(page.content)
+    end
+
+    def v3?
+      ::Jekyll::VERSION.to_f >= 3.0
     end
   end
 end

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe(Jekyll::Emoji) do
   let(:config_overrides) { {} }
   let(:configs) do
     Jekyll.configuration(config_overrides.merge({
-      'skip_config_files' => true,
+      'skip_config_files' => false,
       'collections' => { 'docs' => { 'output' => true }, 'secret' => {} },
       'source' => fixtures_dir,
       'destination' => fixtures_dir('_site')
@@ -12,10 +12,12 @@ RSpec.describe(Jekyll::Emoji) do
   let(:emoji) { site.generators.find { |g| g.class.name.eql?("Jekyll::Emoji") } }
   let(:default_src) { "https://assets.github.com/images/icons/" }
   let(:result) { "<img class='emoji' title=':+1:' alt=':+1:' src='#{default_src}emoji/unicode/1f44d.png' height='20' width='20' align='absmiddle' />" }
+  let(:v3?) { ::Jekyll::VERSION.to_f >= 3.0 }
+  let(:posts) { v3? ? site.posts.docs : site.posts }
 
   before(:each) do
     site.read
-    (site.pages + site.posts + site.docs_to_write).each { |p| p.content.strip! }
+    (site.pages + posts + site.docs_to_write).each { |p| p.content.strip! }
     site.generate
   end
 
@@ -37,7 +39,7 @@ RSpec.describe(Jekyll::Emoji) do
   end
 
   it "correctly replaces the emoji with the img in posts" do
-    expect(site.posts.first.content).to eql(result)
+    expect(posts.first.content).to eql(result)
   end
 
   it "correctly replaces the emoji with the img in pages" do
@@ -71,7 +73,7 @@ RSpec.describe(Jekyll::Emoji) do
     end
 
     it "respects the new base when emojifying" do
-      expect(site.posts.first.content).to eql(result.sub(default_src, emoji_src))
+      expect(posts.first.content).to eql(result.sub(default_src, emoji_src))
     end
   end
 end


### PR DESCRIPTION
So I spent a while debugging an issue with emojification being run twice over posts and think I've tracked it down.

In v3, the call to `site.docs_to_write` also includes the now default posts collection. However there is already a call to `site.posts` [here](https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb#L29). This causes a double emojification resulting in markup like this:

```html
<img class='emoji' title='<img class='emoji' title=':+1:' alt=':+1:' src='https://assets.github.com/images/icons/emoji/unicode/1f44d.png' height='20' width='20' align='absmiddle' />&#39; alt=&#39;<img class='emoji' title=':+1:' alt=':+1:' src='https://assets.github.com/images/icons/emoji/unicode/1f44d.png' height='20' width='20' align='absmiddle' />&#39; src=&#39;https://assets.github.com/images/icons/emoji/unicode/1f44d.png&#39; height=&#39;20&#39; width=&#39;20&#39; align=&#39;absmiddle&#39; /&gt;
```

I've added a check for v3, falling back to v2 behaviour if necessary. The only thing is having to set `skip_config_files` to `false`. This is so that [this](https://github.com/jekyll/jekyll/blob/master/lib/jekyll.rb#L102) conditional is met and in turn [this](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/configuration.rb#L189) is called to populate the default posts collections.