### PR TITLE
jemoji as a hook: better guarding against accidents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0

--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.files    = [ 'lib/jemoji.rb' ]
 
-  s.add_dependency 'jekyll', '>= 2.0'
+  s.add_dependency 'jekyll', '>= 3.0'
   s.add_dependency 'html-pipeline', '~> 2.2'
   s.add_dependency 'gemoji', '~> 2.0'
 

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -46,6 +46,11 @@ module Jekyll
         end
       end
 
+      # Public: Defines the conditions for a document to be emojiable.
+      #
+      # doc - the Jekyll::Document or Jekyll::Page
+      #
+      # Returns true if the doc is written & is HTML.
       def emojiable?(doc)
         (doc.class == Jekyll::Page || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -45,10 +45,15 @@ module Jekyll
           GITHUB_DOT_COM_ASSET_ROOT
         end
       end
+
+      def emojiable?(doc)
+        (doc.class == Jekyll::Page || doc.write?) &&
+          doc.output_ext == ".html"
+      end
     end
   end
 end
 
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
-  Jekyll::Emoji.emojify(doc) if doc.class == Jekyll::Page || doc.write?
+  Jekyll::Emoji.emojify(doc) if Jekyll::Emoji.emojiable?(doc)
 end

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -3,39 +3,52 @@ require 'gemoji'
 require 'html/pipeline'
 
 module Jekyll
-  class Emoji < Jekyll::Generator
-    attr_reader :config
-    safe true
+  class Emoji
+    GITHUB_DOT_COM_ASSET_ROOT = "https://assets.github.com/images/icons/".freeze
 
-    def initialize(config = {})
-      @config = config
-    end
+    class << self
+      def emojify(doc)
+        src = emoji_src(doc.site.config)
+        doc.output = filter_with_emoji(src).call(doc.output)[:output].to_s
+      end
 
-    def src
-      @src ||=
+      # Public: Create or fetch the filter for the given {{src}} asset root.
+      #
+      # src - the asset root URL (e.g. https://assets.github.com/images/icons/)
+      #
+      # Returns an HTML::Pipeline instance for the given asset root.
+      def filter_with_emoji(src)
+        filters[src] ||= HTML::Pipeline.new([
+          HTML::Pipeline::EmojiFilter
+        ], { :asset_root => src })
+      end
+
+      # Public: Filters hash where the key is the asset root source.
+      # Effectively a cache.
+      def filters
+        @filters ||= {}
+      end
+
+      # Public: Calculate the asset root source for the given config.
+      # The custom emoji asset root can be defined in the config as
+      # emoji.src, and must be a valid URL (i.e. it must include a
+      # protocol and valid domain)
+      #
+      # config - the hash-like configuration of the document's site
+      #
+      # Returns a full URL to use as the asset root URL. Defaults to
+      # the assets.github.com emoji root.
+      def emoji_src(config = {})
         if config.key?("emoji") && config["emoji"].key?("src")
           config["emoji"]["src"]
         else
-          "https://assets.github.com/images/icons/"
+          GITHUB_DOT_COM_ASSET_ROOT
         end
-    end
-
-    def filter
-      @filter ||= HTML::Pipeline::EmojiFilter.new(nil, { :asset_root => src })
-    end
-
-    def generate(site)
-      site.posts.each { |doc| emojify doc } unless v3?
-      site.pages.each { |doc| emojify doc }
-      site.docs_to_write.each { |doc| emojify doc }
-    end
-
-    def emojify(page)
-      page.content = filter.emoji_image_filter(page.content)
-    end
-
-    def v3?
-      ::Jekyll::VERSION.to_f >= 3.0
+      end
     end
   end
+end
+
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  Jekyll::Emoji.emojify(doc) if doc.class == Jekyll::Page || doc.write?
 end

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -48,7 +48,7 @@ module Jekyll
 
       def emojiable?(doc)
         (doc.class == Jekyll::Page || doc.write?) &&
-          doc.output_ext == ".html"
+          doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
       end
     end
   end

--- a/spec/fixture_site/_docs/dont_touch_me.txt
+++ b/spec/fixture_site/_docs/dont_touch_me.txt
@@ -1,0 +1,5 @@
+---
+title: Don't Touch Me
+---
+
+:+1:

--- a/spec/fixture_site/_docs/with_liquid.md
+++ b/spec/fixture_site/_docs/with_liquid.md
@@ -1,3 +1,4 @@
 ---
+title: With Liquid
 ---
 :+1: <a href="{{ page.url }}">{{ page.path }}</a>

--- a/spec/fixture_site/_posts/2014-03-08-code-block.md
+++ b/spec/fixture_site/_posts/2014-03-08-code-block.md
@@ -1,0 +1,10 @@
+---
+---
+
+```ruby
+def i_am_ruby
+    puts YAML.dump(":smile: every day")
+end
+```
+
+:+1:

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -16,8 +16,12 @@ RSpec.describe(Jekyll::Emoji) do
   let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
 
   let(:posts)        { site.posts.docs }
-  let(:basic_post)   { posts[1] }
-  let(:complex_post) { posts[0] }
+  let(:basic_post)   { find_by_title(posts, "Refactor") }
+  let(:complex_post) { find_by_title(posts, "Code Block") }
+
+  let(:basic_doc) { find_by_title(site.collections["docs"].docs, "File") }
+  let(:doc_with_liquid) { find_by_title(site.collections["docs"].docs, "With Liquid") }
+  let(:txt_doc) { find_by_title(site.collections["docs"].docs, "Don't Touch Me") }
 
   def para(content)
     "<p>#{content}</p>\n"
@@ -53,7 +57,11 @@ RSpec.describe(Jekyll::Emoji) do
   end
 
   it "correctly replaces the emoji with the img in collection documents" do
-    expect(site.collections["docs"].docs.first.output).to eql(para(result))
+    expect(basic_doc.output).to eql(para(result))
+  end
+
+  it "correctly replaces the emoji with the img in collection documents" do
+    expect(txt_doc.output).to eql(":+1:")
   end
 
   it "does not replace the emoji if the collection document is not to be output" do
@@ -61,7 +69,7 @@ RSpec.describe(Jekyll::Emoji) do
   end
 
   it "does not mangle liquid templates" do
-    expect(site.collections["docs"].docs.last.output).to eql(
+    expect(doc_with_liquid.output).to eql(
       para("#{result} <a href=\"/docs/with_liquid.html\">_docs/with_liquid.md</a>")
     )
   end

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe(Jekyll::Emoji) do
     expect(basic_doc.output).to eql(para(result))
   end
 
-  it "correctly replaces the emoji with the img in collection documents" do
+  it "leaves non-HTML files alone" do
     expect(txt_doc.output).to eql(":+1:")
   end
 

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe(Jekyll::Emoji) do
   let(:site)        { Jekyll::Site.new(configs) }
   let(:default_src) { "https://assets.github.com/images/icons/" }
   let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
-  let(:posts)       { site.posts.docs }
+
+  let(:posts)        { site.posts.docs }
+  let(:basic_post)   { posts[1] }
+  let(:complex_post) { posts[0] }
 
   def para(content)
     "<p>#{content}</p>\n"
@@ -35,7 +38,14 @@ RSpec.describe(Jekyll::Emoji) do
   end
 
   it "correctly replaces the emoji with the img in posts" do
-    expect(posts.first.output).to eql(para(result))
+    expect(basic_post.output).to eql(para(result))
+  end
+
+  it "doesn't replace emoji in a code block" do
+    expect(complex_post.output).to include(
+      "<span class=\"s2\">\":smile: every day\"</span>"
+    )
+    expect(complex_post.output).to include(result)
   end
 
   it "correctly replaces the emoji with the img in pages" do
@@ -69,7 +79,7 @@ RSpec.describe(Jekyll::Emoji) do
     end
 
     it "respects the new base when emojifying" do
-      expect(posts.first.output).to eql(para(result.sub(default_src, emoji_src)))
+      expect(basic_post.output).to eql(para(result.sub(default_src, emoji_src)))
     end
   end
 end

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -1,62 +1,58 @@
 RSpec.describe(Jekyll::Emoji) do
+  Jekyll.logger.log_level = :error
+
   let(:config_overrides) { {} }
   let(:configs) do
     Jekyll.configuration(config_overrides.merge({
       'skip_config_files' => false,
-      'collections' => { 'docs' => { 'output' => true }, 'secret' => {} },
-      'source' => fixtures_dir,
-      'destination' => fixtures_dir('_site')
+      'collections'       => { 'docs' => { 'output' => true }, 'secret' => {} },
+      'source'            => fixtures_dir,
+      'destination'       => fixtures_dir('_site')
     }))
   end
-  let(:site) { Jekyll::Site.new(configs) }
-  let(:emoji) { site.generators.find { |g| g.class.name.eql?("Jekyll::Emoji") } }
+  let(:emoji)       { described_class }
+  let(:site)        { Jekyll::Site.new(configs) }
   let(:default_src) { "https://assets.github.com/images/icons/" }
-  let(:result) { "<img class='emoji' title=':+1:' alt=':+1:' src='#{default_src}emoji/unicode/1f44d.png' height='20' width='20' align='absmiddle' />" }
-  let(:v3?) { ::Jekyll::VERSION.to_f >= 3.0 }
-  let(:posts) { v3? ? site.posts.docs : site.posts }
+  let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
+  let(:posts)       { site.posts.docs }
+
+  def para(content)
+    "<p>#{content}</p>\n"
+  end
 
   before(:each) do
     site.read
     (site.pages + posts + site.docs_to_write).each { |p| p.content.strip! }
-    site.generate
-  end
-
-  it "is instantiated properly with the site" do
-    expect(emoji).not_to be(nil)
-    expect(emoji).to be_a(Jekyll::Emoji)
+    site.render
   end
 
   it "creates a filter" do
-    expect(emoji.filter).to be_a(HTML::Pipeline::EmojiFilter)
+    expect(emoji.filters[default_src]).to be_a(HTML::Pipeline)
   end
 
   it "has a default source" do
-    expect(emoji.src).to eql(default_src)
-  end
-
-  it "saves the site config for later use" do
-    expect(emoji.config).to eql(site.config)
+    expect(emoji.emoji_src).to eql(default_src)
   end
 
   it "correctly replaces the emoji with the img in posts" do
-    expect(posts.first.content).to eql(result)
+    expect(posts.first.output).to eql(para(result))
   end
 
   it "correctly replaces the emoji with the img in pages" do
-    expect(site.pages.first.content).to eql(result)
+    expect(site.pages.first.output).to eql(para(result))
   end
 
   it "correctly replaces the emoji with the img in collection documents" do
-    expect(site.collections["docs"].docs.first.content).to eql(result)
+    expect(site.collections["docs"].docs.first.output).to eql(para(result))
   end
 
   it "does not replace the emoji if the collection document is not to be output" do
-    expect(site.collections["secret"].docs.first.content).to eql(":+1:\n")
+    expect(site.collections["secret"].docs.first.output).to eql(para(":+1:"))
   end
 
   it "does not mangle liquid templates" do
-    expect(site.collections["docs"].docs.last.content).to eql(
-      "#{result} <a href=\"{{ page.url }}\">{{ page.path }}</a>"
+    expect(site.collections["docs"].docs.last.output).to eql(
+      para("#{result} <a href=\"/docs/with_liquid.html\">_docs/with_liquid.md</a>")
     )
   end
 
@@ -69,11 +65,11 @@ RSpec.describe(Jekyll::Emoji) do
     end
 
     it "fetches the custom base from the config" do
-      expect(emoji.src).to eql(emoji_src)
+      expect(emoji.emoji_src(site.config)).to eql(emoji_src)
     end
 
     it "respects the new base when emojifying" do
-      expect(posts.first.content).to eql(result.sub(default_src, emoji_src))
+      expect(posts.first.output).to eql(para(result.sub(default_src, emoji_src)))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ RSpec.configure do |config|
     File.join(FIXTURES_DIR, *paths)
   end
 
+  def find_by_title(docs, title)
+    docs.find { |d| d.title == title }
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Fixes #12. /cc @jingweno
Fixes #4. /cc @benbalter
Replaces #29.

- [x] Register a Jekyll::Hook for pages & documents (which includes posts)
- [x] Use the whole HTML::Pipeline to guard against emojifying to broadly (for #12)
- [x] Update specs
- [x] Lock to Jekyll 3 or greater
- [x] Only run on HTML docs