### PR TITLE
Handle subclassing of Jekyll::Page

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -52,7 +52,7 @@ module Jekyll
       #
       # Returns true if the doc is written & is HTML.
       def emojiable?(doc)
-        (doc.class == Jekyll::Page || doc.write?) &&
+        (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
       end
     end

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe(Jekyll::Emoji) do
   Jekyll.logger.log_level = :error
 


### PR DESCRIPTION
jekyll-sitemap, for example, uses a subclass. This will fix compatibility with that plugin.

/cc @jekyll/gh-pages