### PR TITLE
Added gemoji parser to parse raw unicode emoji input into token form

### DIFF
--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jekyll', '>= 3.0'
   s.add_dependency 'html-pipeline', '~> 2.2'
   s.add_dependency 'gemoji', '~> 2.0'
+  s.add_dependency 'gemoji-parser', '~> 1.3'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -1,5 +1,6 @@
 require 'jekyll'
 require 'gemoji'
+require 'gemoji-parser'
 require 'html/pipeline'
 
 module Jekyll
@@ -9,6 +10,8 @@ module Jekyll
     class << self
       def emojify(doc)
         src = emoji_src(doc.site.config)
+        # tokenize the raw input unicode emoji into token symbol form
+        doc.output = EmojiParser.tokenize(doc.output)
         doc.output = filter_with_emoji(src).call(doc.output)[:output].to_s
       end
 


### PR DESCRIPTION
Rationale : Eliminate the need to refer/memorize [emoji cheatsheet](http://www.emoji-cheat-sheet.com/) .

Added gemoji parser to parse raw unicode emoji input into token form so that it can be emojified into image. 

Type in unicode emoji (Control + Command + Space in OS X)   

<img width="407" alt="screen shot 2016-03-17 at 4 51 28 pm" src="https://cloud.githubusercontent.com/assets/3954625/13840952/ea6e29d0-ec60-11e5-9c7d-bc65d85af725.png">  

And then it get emojified into image  
<img width="933" alt="screen shot 2016-03-17 at 4 50 56 pm" src="https://cloud.githubusercontent.com/assets/3954625/13840985/1601bc7e-ec61-11e5-8ccd-57d6a9354892.png">


