### PR TITLE
Use String#include instead of String#=~

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -5,12 +5,13 @@ require 'html/pipeline'
 module Jekyll
   class Emoji
     GITHUB_DOT_COM_ASSET_ROOT = "https://assets.github.com/images/icons/".freeze
+    BODY_START_TAG = "<body".freeze
 
     class << self
       def emojify(doc)
         return unless doc.output =~ HTML::Pipeline::EmojiFilter.emoji_pattern
         src = emoji_src(doc.site.config)
-        if doc.output =~ /<\s*body/
+        if doc.output.include? BODY_START_TAG
           parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
           body          = parsed_doc.at_css('body')
           body.children = filter_with_emoji(src).call(body.inner_html)[:output].to_s


### PR DESCRIPTION
@benbalter Could we use `include?` here instead of `=~`?

```text
Warming up --------------------------------------
    no body include?   114.533k i/100ms
      no body regexp    40.573k i/100ms
Calculating -------------------------------------
    no body include?      2.443M (± 3.6%) i/s -     12.255M
      no body regexp    507.675k (± 2.3%) i/s -      2.556M

Comparison:
    no body include?:  2442987.7 i/s
      no body regexp:   507675.5 i/s - 4.81x slower

Warming up --------------------------------------
  with body include?   114.182k i/100ms
    with body regexp    40.746k i/100ms
Calculating -------------------------------------
  with body include?      2.334M (± 7.4%) i/s -     11.647M
    with body regexp    450.995k (± 5.8%) i/s -      2.282M

Comparison:
  with body include?:  2334117.9 i/s
    with body regexp:   450995.3 i/s - 5.18x slower
```

Code: https://github.com/jekyll/jekyll/commit/c28a17d71fc58403ec594f8b9356d8fcc92aa52a