### PR TITLE
Add support for setting a default asset host URL in an ASSET_HOST_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ In any page or post, use emoji as you would normally, e.g.
 I give this plugin two :+1:!
 ```
 
+## Emoji images
+
+For GitHub Pages sites built on GitHub.com, emoji images are served from the GitHub.com CDN, with a base URL of `https://assets-cdn.github.com`, which results in emoji image URLs like `https://assets-cdn.github.com/images/icons/emoji/unicode/1f604.png`.
+
+On GitHub Enterprise installs, page builds receive the `ASSET_HOST_URL` environment variable, which contain a value like `https://assets.ghe.my-company.com`. This results in emoji images for GitHub Pages sites built on a GitHub Enterprise install being served at URLs like `https://assets.ghe.my-company.com/images/icons/emoji/unicode/1f604.png`.
+
 ## Customizing
 
 If you'd like to serve emoji images locally, or use a custom emoji source, you can specify so in your `_config.yml` file:

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -4,7 +4,8 @@ require 'html/pipeline'
 
 module Jekyll
   class Emoji
-    GITHUB_DOT_COM_ASSET_ROOT = "https://assets.github.com/images/icons/".freeze
+    GITHUB_DOT_COM_ASSET_HOST_URL = "https://assets.github.com".freeze
+    ASSET_PATH = "/images/icons/".freeze
     BODY_START_TAG = "<body".freeze
 
     class << self
@@ -51,7 +52,7 @@ module Jekyll
         if config.key?("emoji") && config["emoji"].key?("src")
           config["emoji"]["src"]
         else
-          GITHUB_DOT_COM_ASSET_ROOT
+          default_asset_root
         end
       end
 
@@ -63,6 +64,17 @@ module Jekyll
       def emojiable?(doc)
         (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
+      end
+
+      private
+      def default_asset_root
+        if !ENV["ASSET_HOST_URL"].to_s.empty?
+          # Ensure that any trailing "/" is trimmed
+          asset_host_url = ENV["ASSET_HOST_URL"].chomp("/")
+          "#{asset_host_url}#{ASSET_PATH}"
+        else
+          "#{GITHUB_DOT_COM_ASSET_HOST_URL}#{ASSET_PATH}"
+        end
       end
     end
   end

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -67,6 +67,7 @@ module Jekyll
       end
 
       private
+
       def default_asset_root
         if !ENV["ASSET_HOST_URL"].to_s.empty?
           # Ensure that any trailing "/" is trimmed

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -4,7 +4,7 @@ require 'html/pipeline'
 
 module Jekyll
   class Emoji
-    GITHUB_DOT_COM_ASSET_HOST_URL = "https://assets.github.com".freeze
+    GITHUB_DOT_COM_ASSET_HOST_URL = "https://assets-cdn.github.com".freeze
     ASSET_PATH = "/images/icons/".freeze
     BODY_START_TAG = "<body".freeze
 
@@ -24,7 +24,7 @@ module Jekyll
 
       # Public: Create or fetch the filter for the given {{src}} asset root.
       #
-      # src - the asset root URL (e.g. https://assets.github.com/images/icons/)
+      # src - the asset root URL (e.g. https://assets-cdn.github.com/images/icons/)
       #
       # Returns an HTML::Pipeline instance for the given asset root.
       def filter_with_emoji(src)
@@ -46,8 +46,9 @@ module Jekyll
       #
       # config - the hash-like configuration of the document's site
       #
-      # Returns a full URL to use as the asset root URL. Defaults to
-      # the assets.github.com emoji root.
+      # Returns a full URL to use as the asset root URL. Defaults to the root
+      # URL for assets provided by an ASSET_HOST_URL environment variable,
+      # otherwise the root URL for emoji assets at assets-cdn.github.com.
       def emoji_src(config = {})
         if config.key?("emoji") && config["emoji"].key?("src")
           config["emoji"]["src"]

--- a/spec/fixtures/index.html
+++ b/spec/fixtures/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/css/screen.css">
   </head>
   <body class="wrap">
-    <p><img class="emoji" title=":+1:" alt=":+1:" src="https://assets.github.com/images/icons/emoji/unicode/1f44d.png" height="20" width="20" align="absmiddle"></p>
+    <p><img class="emoji" title=":+1:" alt=":+1:" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png" height="20" width="20" align="absmiddle"></p>
 
   </body>
 </html>

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe(Jekyll::Emoji) do
       'destination'       => fixtures_dir('_site')
     }))
   end
-  let(:emoji)       { described_class }
-  let(:site)        { Jekyll::Site.new(configs) }
-  let(:default_src) { "https://assets.github.com/images/icons/" }
-  let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
+  let(:emoji)                { described_class }
+  let(:site)                 { Jekyll::Site.new(configs) }
+  let(:default_src)          { "https://assets.github.com/images/icons/" }
+  let(:asset_host_url)       { "https://assets.github.vm" }
+  let(:default_src_from_env) { "https://assets.github.vm/images/icons/" }
+  let(:result)               { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
 
   let(:posts)        { site.posts.docs }
   let(:basic_post)   { find_by_title(posts, "Refactor") }
@@ -45,6 +47,12 @@ RSpec.describe(Jekyll::Emoji) do
 
   it "has a default source" do
     expect(emoji.emoji_src).to eql(default_src)
+  end
+
+  it "has the correct default source when ASSET_HOST_URL is set" do
+    ENV["ASSET_HOST_URL"] = asset_host_url
+    expect(emoji.emoji_src).to eql(default_src_from_env)
+    ENV["ASSET_HOST_URL"] = nil
   end
 
   it "correctly replaces the emoji with the img in posts" do

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe(Jekyll::Emoji) do
   end
   let(:emoji)       { described_class }
   let(:site)        { Jekyll::Site.new(configs) }
-  let(:default_src) { "https://assets.github.com/images/icons/" }
+  let(:default_src) { "https://assets-cdn.github.com/images/icons/" }
   let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
 
   let(:posts)        { site.posts.docs }

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe(Jekyll::Emoji) do
   it "has the correct default source when ASSET_HOST_URL is set" do
     ENV["ASSET_HOST_URL"] = asset_host_url
     expect(emoji.emoji_src).to eql(default_src_from_env)
+
+    ENV["ASSET_HOST_URL"] = "#{asset_host_url}/"
+    expect(emoji.emoji_src).to eql(default_src_from_env)
+
     ENV["ASSET_HOST_URL"] = nil
   end
 

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -12,12 +12,10 @@ RSpec.describe(Jekyll::Emoji) do
       'destination'       => fixtures_dir('_site')
     }))
   end
-  let(:emoji)                { described_class }
-  let(:site)                 { Jekyll::Site.new(configs) }
-  let(:default_src)          { "https://assets.github.com/images/icons/" }
-  let(:asset_host_url)       { "https://assets.github.vm" }
-  let(:default_src_from_env) { "https://assets.github.vm/images/icons/" }
-  let(:result)               { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
+  let(:emoji)       { described_class }
+  let(:site)        { Jekyll::Site.new(configs) }
+  let(:default_src) { "https://assets.github.com/images/icons/" }
+  let(:result)      { "<img class=\"emoji\" title=\":+1:\" alt=\":+1:\" src=\"#{default_src}emoji/unicode/1f44d.png\" height=\"20\" width=\"20\" align=\"absmiddle\">" }
 
   let(:posts)        { site.posts.docs }
   let(:basic_post)   { find_by_title(posts, "Refactor") }
@@ -47,16 +45,6 @@ RSpec.describe(Jekyll::Emoji) do
 
   it "has a default source" do
     expect(emoji.emoji_src).to eql(default_src)
-  end
-
-  it "has the correct default source when ASSET_HOST_URL is set" do
-    ENV["ASSET_HOST_URL"] = asset_host_url
-    expect(emoji.emoji_src).to eql(default_src_from_env)
-
-    ENV["ASSET_HOST_URL"] = "#{asset_host_url}/"
-    expect(emoji.emoji_src).to eql(default_src_from_env)
-
-    ENV["ASSET_HOST_URL"] = nil
   end
 
   it "correctly replaces the emoji with the img in posts" do
@@ -110,6 +98,28 @@ RSpec.describe(Jekyll::Emoji) do
 
     it "respects the new base when emojifying" do
       expect(basic_post.output).to eql(para(result.sub(default_src, emoji_src)))
+    end
+  end
+
+  context "with the ASSET_HOST_URL environment variable set" do
+    let(:asset_host_url)       { "https://assets.github.vm" }
+    let(:default_src_from_env) { "https://assets.github.vm/images/icons/" }
+
+    before(:each) { ENV["ASSET_HOST_URL"] = asset_host_url }
+    after(:each) { ENV.delete("ASSET_HOST_URL") }
+
+    it "has the correct default source when ASSET_HOST_URL is set" do
+      expect(emoji.emoji_src).to eql(default_src_from_env)
+    end
+
+    it "trims a trailing / if necessary" do
+      ENV["ASSET_HOST_URL"] = "#{asset_host_url}/"
+      expect(emoji.emoji_src).to eql(default_src_from_env)
+    end
+
+    it "falls back to using the default if ASSET_HOST_URL is empty" do
+      ENV["ASSET_HOST_URL"] = ""
+      expect(emoji.emoji_src).to eql(default_src)
     end
   end
 end


### PR DESCRIPTION
This adds support for loading the default asset URL from an `ASSET_HOST_URL` environment variable. In a GitHub Enterprise environment, this supports fixing an issue where assets were being loaded from the GitHub.com rather asset host rather than using the GitHub Enterprise appliance's asset hostname.

For review by @benbalter, @parkr, @jldec.