### PR TITLE
Lock activesupport down to v4.x

### DIFF
--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jekyll', '>= 3.0'
   s.add_dependency 'html-pipeline', '~> 2.2'
+  s.add_dependency 'activesupport', '~> 4.0'
   s.add_dependency 'gemoji', '~> 2.0'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes #46. 

/cc https://github.com/jekyll/jekyll-mentions/issues/36 https://github.com/github/pages-gem/issues/308 https://github.com/jch/html-pipeline/issues/257
/cc @jdennes 