### PR TITLE
bump dependency version of activesupport to 5.0

### DIFF
--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jekyll', '>= 3.0'
   s.add_dependency 'html-pipeline', '~> 2.2'
-  s.add_dependency 'activesupport', '~> 4.0'
+  s.add_dependency 'activesupport', '~> 5.0'
   s.add_dependency 'gemoji', '~> 2.0'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
In Ruby 2.4.0(development version), it can not install activesupport 4.2 caused by Integer Unification changes on json gem.

ref https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200

activesupport 5.0 removed dependency of json. so Ruby 2.4.0 completely works in activesupport 5.0.

I hope to use jemoji gem in Ruby 2.4.0 and future version.