### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jemoji.gemspec
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Style/IndentHeredoc:
+  Exclude:
+    - spec/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
-require 'rubygems'
-require 'bundler/gem_tasks'
+require "rubygems"
+require "bundler/gem_tasks"
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:test) do |t|
     t.rspec_opts = "--color --require spec_helper"
   end
 rescue LoadError
+  nil
 end

--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -1,20 +1,20 @@
 Gem::Specification.new do |s|
-  s.name        = 'jemoji'
-  s.summary     = 'GitHub-flavored emoji plugin for Jekyll'
-  s.version     = '0.8.0'
-  s.authors     = ['GitHub, Inc.']
-  s.email       = 'support@github.com'
+  s.name        = "jemoji"
+  s.summary     = "GitHub-flavored emoji plugin for Jekyll"
+  s.version     = "0.8.0"
+  s.authors     = ["GitHub, Inc."]
+  s.email       = "support@github.com"
 
-  s.homepage = 'https://github.com/jekyll/jemoji'
-  s.licenses = ['MIT']
-  s.files    = [ 'lib/jemoji.rb' ]
+  s.homepage = "https://github.com/jekyll/jemoji"
+  s.licenses = ["MIT"]
+  s.files    = [ "lib/jemoji.rb" ]
 
-  s.add_dependency 'jekyll', '>= 3.0'
-  s.add_dependency 'html-pipeline', '~> 2.2'
-  s.add_dependency 'activesupport', '~> 4.0'
-  s.add_dependency 'gemoji', '~> 3.0'
+  s.add_dependency "jekyll", ">= 3.0"
+  s.add_dependency "html-pipeline", "~> 2.2"
+  s.add_dependency "activesupport", "~> 4.0"
+  s.add_dependency "gemoji", "~> 3.0"
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rdoc"
+  s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -1,6 +1,6 @@
-require 'jekyll'
-require 'gemoji'
-require 'html/pipeline'
+require "jekyll"
+require "gemoji"
+require "html/pipeline"
 
 module Jekyll
   class Emoji
@@ -14,7 +14,7 @@ module Jekyll
         src = emoji_src(doc.site.config)
         if doc.output.include? BODY_START_TAG
           parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
-          body          = parsed_doc.at_css('body')
+          body          = parsed_doc.at_css("body")
           body.children = filter_with_emoji(src).call(body.inner_html)[:output].to_s
           doc.output    = parsed_doc.to_html
         else
@@ -29,8 +29,8 @@ module Jekyll
       # Returns an HTML::Pipeline instance for the given asset root.
       def filter_with_emoji(src)
         filters[src] ||= HTML::Pipeline.new([
-          HTML::Pipeline::EmojiFilter
-        ], { :asset_root => src, img_attrs: { align: nil } })
+          HTML::Pipeline::EmojiFilter,
+        ], { :asset_root => src, :img_attrs => { :align => nil } })
       end
 
       # Public: Filters hash where the key is the asset root source.

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe(Jekyll::Emoji) do
   Jekyll.logger.log_level = :error
@@ -6,10 +6,10 @@ RSpec.describe(Jekyll::Emoji) do
   let(:config_overrides) { {} }
   let(:configs) do
     Jekyll.configuration(config_overrides.merge({
-      'skip_config_files' => false,
-      'collections'       => { 'docs' => { 'output' => true }, 'secret' => {} },
-      'source'            => fixtures_dir,
-      'destination'       => fixtures_dir('_site')
+      "skip_config_files" => false,
+      "collections"       => { "docs" => { "output" => true }, "secret" => {} },
+      "source"            => fixtures_dir,
+      "destination"       => fixtures_dir("_site"),
     }))
   end
   let(:emoji)       { described_class }
@@ -88,7 +88,7 @@ RSpec.describe(Jekyll::Emoji) do
     let(:emoji_src) { "http://mine.club/" }
     let(:config_overrides) do
       {
-        "emoji" => { "src" => emoji_src }
+        "emoji" => { "src" => emoji_src },
       }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
-require File.expand_path('../../lib/jemoji.rb', __FILE__)
+require File.expand_path("../../lib/jemoji.rb", __FILE__)
 
 RSpec.configure do |config|
-  FIXTURES_DIR = File.expand_path('../fixture_site', __FILE__)
+  FIXTURES_DIR = File.expand_path("../fixture_site", __FILE__)
   def fixtures_dir(*paths)
     File.join(FIXTURES_DIR, *paths)
   end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.