### PR TITLE
Let Nokogiri parse only the necessary markup

### DIFF
--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency "jekyll", "~> 3.0"
 
   s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "rubocop", "~> 0.51"
+  s.add_development_dependency "rubocop", "~> 0.51.0"
 end

--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -9,6 +9,7 @@ module Jekyll
     GITHUB_DOT_COM_ASSET_HOST_URL = "https://assets-cdn.github.com".freeze
     ASSET_PATH = "/images/icons/".freeze
     BODY_START_TAG = "<body".freeze
+    OPENING_BODY_TAG_REGEX = %r!<body(.*)>\s*!
 
     class << self
       def emojify(doc)
@@ -79,11 +80,11 @@ module Jekyll
       end
 
       def replace_document_body(doc)
-        src           = emoji_src(doc.site.config)
-        parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
-        body          = parsed_doc.at_css("body")
-        body.children = filter_with_emoji(src).call(body.inner_html)[:output].to_s
-        parsed_doc.to_html
+        src                 = emoji_src(doc.site.config)
+        head, opener, tail  = doc.output.partition(OPENING_BODY_TAG_REGEX)
+        body_content, *rest = tail.partition("</body>")
+        processed_markup    = filter_with_emoji(src).call(body_content)[:output].to_s
+        String.new(head) << opener << processed_markup << rest.join
       end
     end
   end

--- a/spec/fixtures/index.html
+++ b/spec/fixtures/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html lang="en-US">
   <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="UTF-8">
     <title>Jemoji</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
Instead of having Nokogiri parse the entire HTML doc and then selectively apply the emojify_filter to just the contents of the `<body>` tag, let's have Nokogiri parse just the `<body>` tag descendants instead

The *emojified* markup is then inserted back into `doc.output` via `String#<<`