### PR TITLE
Relax version constraint on ActiveSupport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.2
 before_install: 
 - gem update --system
+- gem install bundler
 before_script: bundle update
 script: script/cibuild
 branches:

--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.1"
 
-  s.add_dependency "activesupport", "~> 4.0", ">= 4.2.9"
+  s.add_dependency "activesupport", ">= 4.2.9", "< 6.0"
   s.add_dependency "gemoji", "~> 3.0"
   s.add_dependency "html-pipeline", "~> 2.2"
   s.add_dependency "jekyll", "~> 3.0"


### PR DESCRIPTION
(Rubocop failures will be handled by #75)