### PR TITLE
Better support for custom emoji source path

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -7,7 +7,9 @@ require "html/pipeline"
 module Jekyll
   class Emoji
     GITHUB_DOT_COM_ASSET_HOST_URL = "https://github.githubassets.com"
-    ASSET_PATH = "/images/icons/"
+    ASSET_PATH = "/images/icons"
+    DEFAULT_DIR = "/emoji"
+    FILE_NAME = "/:file_name"
     BODY_START_TAG = "<body"
     OPENING_BODY_TAG_REGEX = %r!<body(.*?)>\s*!m.freeze
 
@@ -18,20 +20,40 @@ module Jekyll
         doc.output = if doc.output.include? BODY_START_TAG
                        replace_document_body(doc)
                      else
-                       src = emoji_src(doc.site.config)
-                       filter_with_emoji(src).call(doc.output)[:output].to_s
+                       src_root = emoji_src_root(doc.site.config)
+                       asset_path = emoji_asset_path(doc.site.config)
+                       filter_with_emoji(src_root, asset_path).call(doc.output)[:output].to_s
                      end
       end
 
-      # Public: Create or fetch the filter for the given {{src}} asset root.
+      # Public: Create or fetch the filter for the given {{src_root}} asset root.
       #
-      # src - the asset root URL (e.g. https://github.githubassets.com/images/icons/)
+      # src_root - the asset root URL (e.g. https://github.githubassets.com/images/icons/)
+      # asset_path - the asset sub-path of src (e.g. "/images/icons")
+      #
+      # if asset_path it's not provided by user in _config.yml file, html pipeline module
+      # will default it to value "emoji"
+      #
+      # examples of _config.yml:
+      #   1. user provided all URLs:
+      #       emoji:
+      #           src: https://example.com/asset
+      #           asset: /images/png
+      #   emoji files will serve from https://example.com/asset/images/png
+      #
+      #   2. user provided just src:
+      #       emoji:
+      #           src: https://example.com/asset
+      #   emoji files will serve from https://example.com/emoji
+      #
+      #   3. user provided nothing:
+      #   emoji files will serve from https://github.githubassets.com/images/icons/emoji
       #
       # Returns an HTML::Pipeline instance for the given asset root.
-      def filter_with_emoji(src)
-        filters[src] ||= HTML::Pipeline.new([
+      def filter_with_emoji(src_root, asset_path)
+        filters[src_root] ||= HTML::Pipeline.new([
           HTML::Pipeline::EmojiFilter,
-        ], :asset_root => src, :img_attrs => { :align => nil })
+        ], :asset_root => src_root, :asset_path => asset_path, :img_attrs => { :align => nil })
       end
 
       # Public: Filters hash where the key is the asset root source.
@@ -42,7 +64,7 @@ module Jekyll
 
       # Public: Calculate the asset root source for the given config.
       # The custom emoji asset root can be defined in the config as
-      # emoji.src, and must be a valid URL (i.e. it must include a
+      # emoji.src_root, and must be a valid URL (i.e. it must include a
       # protocol and valid domain)
       #
       # config - the hash-like configuration of the document's site
@@ -50,11 +72,36 @@ module Jekyll
       # Returns a full URL to use as the asset root URL. Defaults to the root
       # URL for assets provided by an ASSET_HOST_URL environment variable,
       # otherwise the root URL for emoji assets at assets-cdn.github.com.
-      def emoji_src(config = {})
+      def emoji_src_root(config = {})
         if config.key?("emoji") && config["emoji"].key?("src")
           config["emoji"]["src"]
         else
           default_asset_root
+        end
+      end
+
+      # Public: Calculate the asset path for the given config.
+      # The custom emoji asset root can be defined in the config as
+      # emoji.asset.
+      #
+      # If emoji.asset isn't defined, its value will explicitly set to "emoji"
+      #
+      # config - the hash-like configuration of the document's site
+      #
+      # Returns a string to use as the asset path. Defaults to the ASSET_PATH/emoji.
+      def emoji_asset_path(config = {})
+        if config.key?("emoji") && config["emoji"].key?("src")
+          if config["emoji"].key?("asset")
+            # Ensure that any trailing "/" in asset path is trimmed
+            # because FILE_NAME starts with a "/"
+            config["emoji"]["asset"].chomp("/") + FILE_NAME.to_s
+          else
+            "#{DEFAULT_DIR}#{FILE_NAME}"
+          end
+        else
+          # Avoid breaking existing installations by appending DEFAULT_DIR ("/emoji")
+          # to ASSET_PATH ("/images/icons")
+          "#{ASSET_PATH}#{DEFAULT_DIR}#{FILE_NAME}"
         end
       end
 
@@ -74,17 +121,18 @@ module Jekyll
         if !ENV["ASSET_HOST_URL"].to_s.empty?
           # Ensure that any trailing "/" is trimmed
           asset_host_url = ENV["ASSET_HOST_URL"].chomp("/")
-          "#{asset_host_url}#{ASSET_PATH}"
+          asset_host_url.to_s
         else
-          "#{GITHUB_DOT_COM_ASSET_HOST_URL}#{ASSET_PATH}"
+          GITHUB_DOT_COM_ASSET_HOST_URL.to_s
         end
       end
 
       def replace_document_body(doc)
-        src                 = emoji_src(doc.site.config)
-        head, opener, tail  = doc.output.partition(OPENING_BODY_TAG_REGEX)
+        src_root = emoji_src_root(doc.site.config)
+        asset_path = emoji_asset_path(doc.site.config)
+        head, opener, tail = doc.output.partition(OPENING_BODY_TAG_REGEX)
         body_content, *rest = tail.partition("</body>")
-        processed_markup    = filter_with_emoji(src).call(body_content)[:output].to_s
+        processed_markup = filter_with_emoji(src_root, asset_path).call(body_content)[:output].to_s
         String.new(head) << opener << processed_markup << rest.join
       end
     end

--- a/spec/jemoji_spec.rb
+++ b/spec/jemoji_spec.rb
@@ -16,10 +16,13 @@ RSpec.describe(Jekyll::Emoji) do
   end
   let(:emoji)       { described_class }
   let(:site)        { Jekyll::Site.new(configs) }
-  let(:default_src) { "https://github.githubassets.com/images/icons/" }
+  let(:default_src) { "https://github.githubassets.com" }
+  let(:default_asset_path) { "/images/icons" }
+  let(:default_directory) { "/emoji" }
+  let(:default_file_name) { "/:file_name" }
   let(:result) do
     <<-STR.strip
-    <img class="emoji" title=":+1:" alt=":+1:" src="#{default_src}emoji/unicode/1f44d.png" height="20" width="20">
+    <img class="emoji" title=":+1:" alt=":+1:" src="#{default_src}#{default_asset_path}#{default_directory}/unicode/1f44d.png" height="20" width="20">
     STR
   end
 
@@ -58,7 +61,7 @@ RSpec.describe(Jekyll::Emoji) do
   end
 
   it "has a default source" do
-    expect(emoji.emoji_src).to eql(default_src)
+    expect(emoji.emoji_src_root).to eql(default_src)
   end
 
   it "correctly replaces the emoji with the img in posts" do
@@ -108,42 +111,42 @@ RSpec.describe(Jekyll::Emoji) do
     expect(multiline_body_tag.output).to eql(fixture("multiline_body_tag.html"))
   end
 
-  context "with a different base for jemoji" do
-    let(:emoji_src) { "http://mine.club/" }
+  context "with a different base for jemoji (without asset path)" do
+    let(:emoji_src_root) { "http://mine.club" }
     let(:config_overrides) do
       {
-        "emoji" => { "src" => emoji_src },
+        "emoji" => { "src" => emoji_src_root },
       }
     end
 
-    it "fetches the custom base from the config" do
-      expect(emoji.emoji_src(site.config)).to eql(emoji_src)
+    it "fetches the custom base from the config (without asset path)" do
+      expect(emoji.emoji_src_root(site.config)).to eql(emoji_src_root)
     end
 
-    it "respects the new base when emojifying" do
-      expect(basic_post.output).to eql(para(result.sub(default_src, emoji_src)))
+    it "respects the new base when emojifying (without asset path)" do
+      expect(basic_post.output).to eql(para(result.sub("#{default_src}#{default_asset_path}", emoji_src_root)))
     end
   end
 
   context "with the ASSET_HOST_URL environment variable set" do
     let(:asset_host_url)       { "https://assets.github.vm" }
-    let(:default_src_from_env) { "https://assets.github.vm/images/icons/" }
+    let(:default_src_from_env) { "https://assets.github.vm/images/icons" }
 
     before(:each) { ENV["ASSET_HOST_URL"] = asset_host_url }
     after(:each) { ENV.delete("ASSET_HOST_URL") }
 
     it "has the correct default source when ASSET_HOST_URL is set" do
-      expect(emoji.emoji_src).to eql(default_src_from_env)
+      expect(emoji.emoji_src_root + default_asset_path).to eql(default_src_from_env)
     end
 
     it "trims a trailing / if necessary" do
       ENV["ASSET_HOST_URL"] = "#{asset_host_url}/"
-      expect(emoji.emoji_src).to eql(default_src_from_env)
+      expect(emoji.emoji_src_root + default_asset_path).to eql(default_src_from_env)
     end
 
     it "falls back to using the default if ASSET_HOST_URL is empty" do
       ENV["ASSET_HOST_URL"] = ""
-      expect(emoji.emoji_src).to eql(default_src)
+      expect(emoji.emoji_src_root).to eql(default_src)
     end
   end
 end


### PR DESCRIPTION
Hi
Let's start with some history, actually your history ...

https://github.com/jekyll/jemoji/issues/73#issue-302901989
https://github.com/jekyll/jemoji/issues/51#issuecomment-270470974

as you see people have problems with something ridiculous called "emoji" directory appended to every thing by default and without any possible way to disable it 👎  even with this little (actually nothing) option:

```yaml
emoji:
   src: "something/that/doesn't/matter/at/all/because/jemoji/will/append/'emoji'/"
# FACT: no documentation! users have to see a broken link and try to guess
# what the hell is wrong!
```

I went into this problem too (are you surprised?), I googled and then read your entire issue list only to find out **this problem existed for 3 years** and you just said:

> https://github.com/jekyll/jemoji/issues/73#issuecomment-404057945

after this reply I understood that **no maintainer gives a damn about this problem**. So I moved on to fix this by myself (**_I had 0% knowledge of Ruby this morning, I might have 5% now_**).

Now lets see what causes this **PAIN IN THE ASS**:

filter_with_emoji function is the key function here:
```ruby
      # Public: Create or fetch the filter for the given {{src}} asset root.
      #
      # src - the asset root URL (e.g. https://github.githubassets.com/images/icons/)
      #
      # Returns an HTML::Pipeline instance for the given asset root.
      def filter_with_emoji(src)
        filters[src] ||= HTML::Pipeline.new([
          HTML::Pipeline::EmojiFilter,
        ], :asset_root => src, :img_attrs => { :align => nil })
      end
```
filter_with_emoji uses html pipeline gem, the "emoji" directory is appended by this module
file: https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/emoji_filter.rb

```ruby
# frozen_string_literal: true

require 'cgi'
HTML::Pipeline.require_dependency('gemoji', 'EmojiFilter')

module HTML
  class Pipeline
    # HTML filter that replaces :emoji: with images.
    #
    # Context:
    #   :asset_root (required) - base url to link to emoji sprite
    #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
    #   :ignored_ancestor_tags (optional) - Tags to stop the emojification. Node has matched ancestor HTML tags will not be emojified. Default to pre, code, and tt tags. Extra tags please pass in the form of array, e.g., %w(blockquote summary).
    #   :img_attrs (optional) - Attributes for generated img tag. E.g. Pass { "draggble" => true, "height" => nil } to set draggable attribute to "true" and clear height attribute of generated img tag.
```

if you didn't/can't find your sins (yes, its your mistake) in the above code, let me guide you:

> **_:asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder_**

I guess when you were busy writing jemoji, you saw this line and told yourselves: 

> **"It's optional and if we don't give this argument to the pipeline function, nothing would possibly go wrong"**

 😄 YEAH NOTHING ... 
Exceptionally brilliant way of reading source docs, if it's **optional** then why should I even bother myself looking at what it does? 

Let's see whats **wrong**:

```ruby
      # The url path to link emoji sprites
      #
      # :file_name can be used in the asset_path as a placeholder for the sprite file name. If no asset_path is set in the context "emoji/:file_name" is used.
      # Returns the context's asset_path or the default path if no context asset_path is given.
      def asset_path(name)
        if context[:asset_path]
          context[:asset_path].gsub(':file_name', emoji_filename(name))
        else
          File.join('emoji', emoji_filename(name))
        end
      end
```
now you see this right? if you don't provide the :asseth_path, pipeline will append "emoji" to filenames,
and your brilliant way for "Customizing" as explained in README.md is useless as hell because no one can simply serve any emoji from a CDN like https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f600.png

Now, I (some random guy with 0% Ruby knowledge) had fixed this in 1 day (the same thing you didn't give a damn for 3 years). 

I have fixed it in a way that it won't break current installations, and let people get rid of "emoji" directory, by a simple new keyword called "asset":
```yaml
emoji:
   src: "something/that/does/matter/because/jemoji/won't/append/'emoji'/"
   asset: "and/this/path/will/be/appended/instead"
# emojis will serve from this URL:
# "something/that/does/matter/because/jemoji/won't/append/'emoji'/and/this/path/will/be/appended/instead"
```
backward compatibility ensures if user doesn't define "asset", or "emoji" at all, "emoji" directory will appended and this won't break anything (something you should know about me is that I don't like testing, so if I were you, I wouldn't trust this)

and I didn't touch README.md because I suck at English, someone else with proper grammar understanding should edit and update it. 


Best,
Mahdi

(Oh, I was about to forget apologizing for being a bit salty and flaming you in this message. Sorry)

