### PR TITLE
Don't load Gemoji into memory immediately

### DIFF
--- a/lib/jemoji.rb
+++ b/lib/jemoji.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "jekyll"
-require "gemoji"
 require "html/pipeline"
 
 module Jekyll


### PR DESCRIPTION
Jekyll loads all plugins at a very early stage in the build process.
However, `lib/emoji.rb` doesn't directly reference any object initialized by the `gemoji` gem. The heavy-lifting is done by `html-pipeline` gem (which ultimately loads the `gemoji` library anyway, but it does so much later, after Jekyll's `:post_render` has been triggered).

For the curious, you may run the following script (via Bundler) to get an idea:
```ruby
require 'memory_profiler'
MemoryProfiler.report { require 'gemoji' }.pretty_print(scale_bytes: true)
```