### PR TITLE
Upgrade gemoji to v4.x

### DIFF
--- a/jemoji.gemspec
+++ b/jemoji.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4.0"
 
-  s.add_dependency "gemoji", "~> 3.0"
+  s.add_dependency "gemoji", "~> 4.0"
   s.add_dependency "html-pipeline", "~> 2.2"
   s.add_dependency "jekyll", ">= 3.0", "< 5.0"
 


### PR DESCRIPTION
DO NOT MERGE. We should allow gemoji v3.x.

Let's see what happens to our tests for gemoji v4.x