### PR TITLE
Upgrade Rubocop target version to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,6 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   Exclude:
     - vendor/**/*


### PR DESCRIPTION
2.4 is no longer supported.