### PR TITLE
Update .github/workflows/release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,20 @@
-name: Release Gem
+---
+# Dependabot automatically keeps our packages up to date
+# Docs: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
 
-on:
-  push:
-    branches:
-      - master
-    paths:
-      - "lib/**/version.rb"
-
-jobs:
-  release:
-    if: "github.repository_owner == 'jekyll'"
-    name: "Release Gem (Ruby ${{ matrix.ruby_version }})"
-    runs-on: "ubuntu-latest"
-    strategy:
-      fail-fast: true
-      matrix:
-        ruby_version:
-          - 2.7
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - name: "Set up Ruby ${{ matrix.ruby_version }}"
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: Build and Publish Gem
-        uses: ashmaroli/release-gem@dist
-        with:
-          gemspec_name: jemoji
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_GEM_PUSH_API_KEY }}
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  reviewers:
+  - jekyll/plugin-core
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  reviewers:
+  - jekyll/plugin-core


### PR DESCRIPTION
Hey @jekyll/plugin-core!

There's been an update to the `.github/workflows/release.yaml` file template in jekyll/jekyllbot. This PR should bring this repo up to date.

Thanks! :revolving_hearts: :sparkles: :bot:
